### PR TITLE
docs: fixes prop name of point component in docs

### DIFF
--- a/components/point.md
+++ b/components/point.md
@@ -12,9 +12,9 @@
 ## Props
 
 | Name             | Type                               | Default  | Description                                                                      |
-| ---------------- | ---------------------------------- | -------- | -------------------------------------------------------------------------------- |
+|------------------| ---------------------------------- | -------- | -------------------------------------------------------------------------------- |
 | `position`       | `PossibleVector2`                  | `[0,0]`  | The position of the point.                                                       |
-| `stroke`         | `string`                           | `#000`   | The stroke of the point and label (if applicable).                               |
+| `color`          | `string`                           | `#000`   | The color of the point and label (if applicable).                               |
 | `label`          | `string`                           | _none_   | The label of the point.                                                          |
 | `label-position` | `"left"\|"right"\|"top"\|"bottom"` | `bottom` | The position of the label relative to the point.                                 |
 | `filled`         | `boolean`                          | `true`   | Whether the point should be filled.                                              |


### PR DESCRIPTION
I checked the prop name when I saw it wasn't working:

https://github.com/ksassnowski/vueclid/blob/67ed3e6cf97bd4a53b700432e1bd6b5d0d242f8e/src/components/Point.vue#L40-L49

changed `stroke` to `color` in the table.


![phpstorm64_o4CDXOCLCm](https://github.com/user-attachments/assets/872ae10f-d94f-4326-a58e-0d15836f7304)
